### PR TITLE
Fixed some unclear/wrong folder destintions (Creation Kit)

### DIFF
--- a/_09-How-Do-i/ModdingGuide.md
+++ b/_09-How-Do-i/ModdingGuide.md
@@ -251,10 +251,10 @@ More crash help here <https://github.com/Fikthenig/Crash-Bonanza>
 4. Replace your "Steam/steamapps/commom/Skyrim Special Edition" files with the ones you just downloaded
 
 
-* Copy Papyrus Compiler folder from "Steam/steamapps/commom/Skyrim Special Edition" into <Wildlander install folder>/Stock game
-* Copy Creation kit.exe from "Steam/steamapps/commom/Skyrim Special Edition" into <Wildlander install folder>/Stock game  
-* Unzip "Steam/steamapps/commom/Skyrim Special Edition/Data/Scripts.zip" into <Wildlander install folder>/Stock game/Data
-* Download https://www.nexusmods.com/skyrimspecialedition/mods/20061 and unzip contents into <Wildlander install folder>/Stock game
+* Copy Papyrus Compiler folder from "Steam/steamapps/commom/Skyrim Special Edition" into [Wildlander install folder]/Stock game
+* Copy Creation kit.exe from "Steam/steamapps/commom/Skyrim Special Edition" into [Wildlander install folder]/Stock game  
+* Unzip "Steam/steamapps/commom/Skyrim Special Edition/Data/Scripts.zip" into [Wildlander install folder]/Stock game/Data
+* Download https://www.nexusmods.com/skyrimspecialedition/mods/20061 and unzip contents into [Wildlander install folder]/Stock game
 
 When starting Creation Kit now via Mod Manager 2, it throuws a warning regarding wrong version, but it works
 


### PR DESCRIPTION
This should be more understandble.

This section seems to be still wrong: It seems the files downloaded from Steam Depot have been updated and won't work with SSE 1.5.97 anymore? Needs investigation.